### PR TITLE
Fix client not being added to the Class 'this' context via the init function

### DIFF
--- a/src/DiscordRankup.ts
+++ b/src/DiscordRankup.ts
@@ -37,6 +37,7 @@ class DiscordRankup {
   ) {
     // Connect to the database
     this.mongoURL = url;
+    this.client = client;
     return await mongoose.connect(url, options);
   }
 


### PR DESCRIPTION
In the init function, the Discord.js Client class would not be added to the `this` context, making it so that the `levelUp` and `levelDown` events couldn't be emitted, giving the following error:
```js
D:\Github\scrappy-bot\node_modules\discord-rankup\lib\DiscordRankup.js:338
            this.client.emit('levelUp', event);
                        ^

TypeError: Cannot read properties of undefined (reading 'emit')
    at DiscordRankup.levelChange (D:\Github\scrappy-bot\node_modules\discord-rankup\lib\DiscordRankup.js:338:25)
    at DiscordRankup.<anonymous> (D:\Github\scrappy-bot\node_modules\discord-rankup\lib\DiscordRankup.js:112:22)
    at Generator.next (<anonymous>)
    at fulfilled (D:\Github\scrappy-bot\node_modules\discord-rankup\lib\DiscordRankup.js:5:58)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

Node.js v20.7.0
```
This pull request adds the `Client` class to the `this` context, making it so `emit` can be called.